### PR TITLE
Improve instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,9 @@ Install all the dependencies using composer
 
     composer install
 
-Copy the example app config file and make the required configuration changes in the config/app.php file
+Configure your database settings in the `config/app.php` file(See: Datasource/default)
 
-    cp config/app.php.default config/app.php
+    vi config/app.php
 
 Run the database migrations (**Set the database connection in app.php**)
 


### PR DESCRIPTION
- No need to copy `config/app.php`. This is done by `composer install`.
- Clarify where is the point of configuration(Only database settings is minimum)